### PR TITLE
add words comprising email to weak words list

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/devise_zxcvbn.gemspec
+++ b/devise_zxcvbn.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec", "~> 2.14"
 
   spec.add_runtime_dependency "devise"
   spec.add_runtime_dependency("zxcvbn-ruby", ">= 0.0.2")

--- a/lib/devise_zxcvbn/email_tokeniser.rb
+++ b/lib/devise_zxcvbn/email_tokeniser.rb
@@ -1,0 +1,7 @@
+module DeviseZxcvbn
+  class EmailTokeniser
+    def self.split(email_address)
+      email_address.split(/[[:^word:]_]/)
+    end
+  end
+end

--- a/lib/devise_zxcvbn/model.rb
+++ b/lib/devise_zxcvbn/model.rb
@@ -1,3 +1,5 @@
+require 'devise_zxcvbn/email_tokeniser'
+
 module Devise
   module Models
     module Zxcvbnable
@@ -12,7 +14,8 @@ module Devise
       private
 
       def not_weak_password
-        password_score = ::Zxcvbn.test(password, [self.email]).score
+        weak_words = [self.email] + DeviseZxcvbn::EmailTokeniser.split(self.email)
+        password_score = ::Zxcvbn.test(password, weak_words).score
         if password_score < min_password_score
           self.errors.add :password, :weak_password, score: password_score, min_password_score: min_password_score
           return false

--- a/spec/devise_zxcvbn/email_tokeniser_spec.rb
+++ b/spec/devise_zxcvbn/email_tokeniser_spec.rb
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+require 'devise_zxcvbn/email_tokeniser'
+
+describe DeviseZxcvbn::EmailTokeniser do
+  it "should split an email into tokens" do
+    expect(split("joe_bloggs@digital.gov-office.gov.uk")).to eq(%w(joe bloggs digital gov office gov uk))
+  end
+
+  it "should not split non-ascii characters" do
+    expect(split("björn@email.com")).to eq(%w(björn email com))
+  end
+
+  def split(email)
+    DeviseZxcvbn::EmailTokeniser.split(email)
+  end
+end


### PR DESCRIPTION
Before this change, only the email address in its entirety is added
to the weak words list. This is a problem because many email addresses
are of the form `firstname.lastname@something` and passwords including `firstname` or `lastname` are
weak, obvious passwords.

This change adds all email address "tokens" to the weak words list.
