### PR TITLE
Change the zxcvbn implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/devise_zxcvbn.png)](http://badge.fury.io/rb/devise_zxcvbn)
 
-Plugin for [devise](https://github.com/plataformatec/devise) to reject weak passwords, using [zxcvbn-ruby](https://github.com/envato/zxcvbn-ruby) which is a ruby port of [zxcvbn: realistic password strength estimation](https://tech.dropbox.com/2012/04/zxcvbn-realistic-password-strength-estimation/).
+Plugin for [devise](https://github.com/plataformatec/devise) to reject weak passwords, using [zxcvbn-js](https://github.com/bitzesty/zxcvbn-js) which is a ruby port of [zxcvbn: realistic password strength estimation](https://tech.dropbox.com/2012/04/zxcvbn-realistic-password-strength-estimation/).
 The user's password will be rejected if the score is below 4 by default. It also uses the email as user input to zxcvbn, to downscore passwords containing the email.
 
 The scores 0, 1, 2, 3 or 4 are given when the estimated crack time (seconds) is less than `10**2`, `10**4`, `10**6`, `10**8`, Infinity.

--- a/devise_zxcvbn.gemspec
+++ b/devise_zxcvbn.gemspec
@@ -6,9 +6,9 @@ require 'devise_zxcvbn/version'
 Gem::Specification.new do |spec|
   spec.name          = "devise_zxcvbn"
   spec.version       = DeviseZxcvbn::VERSION
-  spec.authors       = ["Matthew Ford"]
-  spec.email         = ["matt@bitzesty.com"]
-  spec.description   = %q{It adds password strength checking via ruby-zxcvbn to reject weak passwords }
+  spec.authors       = ["Bit Zesty"]
+  spec.email         = ["info@bitzesty.com"]
+  spec.description   = %q{This gems works with devise to provide backend password strength checking via zxcvbn-js to reject weak passwords }
   spec.summary       = %q{Devise plugin to reject weak passwords}
   spec.homepage      = "https://github.com/bitzesty/devise_zxcvbn"
   spec.license       = "MIT"
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 2.14"
 
   spec.add_runtime_dependency "devise"
-  spec.add_runtime_dependency("zxcvbn-ruby", ">= 0.0.2")
+  spec.add_runtime_dependency("zxcvbn-js", "~> 4.2.0")
 end

--- a/lib/devise_zxcvbn.rb
+++ b/lib/devise_zxcvbn.rb
@@ -9,16 +9,20 @@ module Devise
   def self.min_password_score
     @@min_password_score
   end
-    
+
   def self.min_password_score=(score)
     if (0..4).include?(score)
       if score < 3
-        ::Rails.logger.warn "[devise_zxcvbn] A score of less than 3 is not recommended." 
+        ::Rails.logger.warn "[devise_zxcvbn] A score of less than 3 is not recommended."
       end
       @@min_password_score = score
     else
       raise "The min_password_score must be an integer and between 0..4"
     end
+  end
+
+  def self.zxcvbn_tester
+    @@zxcvbn_tester ||= ::Zxcvbn::Tester.new
   end
 end
 

--- a/lib/devise_zxcvbn/model.rb
+++ b/lib/devise_zxcvbn/model.rb
@@ -6,6 +6,7 @@ module Devise
       extend ActiveSupport::Concern
 
       delegate :min_password_score, to: "self.class"
+      delegate :zxcvbn_tester, to: "self.class"
 
       included do
         validate :not_weak_password, if: :password_required?
@@ -26,6 +27,7 @@ module Devise
 
       module ClassMethods
         Devise::Models.config(self, :min_password_score)
+        Devise::Models.config(self, :zxcvbn_tester)
 
         def password_score(user, arg_email=nil)
           password = user.respond_to?(:password) ? user.password : user
@@ -48,7 +50,7 @@ module Devise
             zxcvbn_weak_words += local_weak_words
           end
 
-          ::Zxcvbn.test(password, zxcvbn_weak_words).score
+          zxcvbn_tester.test(password, zxcvbn_weak_words).score
         end
       end
     end

--- a/lib/devise_zxcvbn/version.rb
+++ b/lib/devise_zxcvbn/version.rb
@@ -1,3 +1,3 @@
 module DeviseZxcvbn
-  VERSION = "1.1.3"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
We're switching to our fork which achieves the same results as the current
JS implementation.

zxcvbn-js achieves this by running the same code via ExecJS which should mean
that it is easier to keep in sync (when doing both client side and backend validation).

Solves #11 