### PR TITLE
Handle empty passwords

### DIFF
--- a/lib/devise_zxcvbn/model.rb
+++ b/lib/devise_zxcvbn/model.rb
@@ -49,7 +49,7 @@ module Devise
         Devise::Models.config(self, :zxcvbn_tester)
 
         def password_score(user, arg_email=nil)
-          password = user.respond_to?(:password) ? user.password : user
+          password = user.respond_to?(:password) ? user.password.to_s : user
 
           zxcvbn_weak_words = []
 


### PR DESCRIPTION
After upgrading from 1.1.2 to 2.1.0 we noticed the Javascript (Object.matching.dictionary_match) fails when handed an empty password. This fixes that and thus restores the 1.x behavior.