### PR TITLE
Fix bug on EmailTokeniser when email is nil

### DIFF
--- a/lib/devise_zxcvbn/email_tokeniser.rb
+++ b/lib/devise_zxcvbn/email_tokeniser.rb
@@ -1,7 +1,7 @@
 module DeviseZxcvbn
   class EmailTokeniser
     def self.split(email_address)
-      email_address.split(/[[:^word:]_]/)
+      email_address.to_s.split(/[[:^word:]_]/)
     end
   end
 end

--- a/spec/devise_zxcvbn/email_tokeniser_spec.rb
+++ b/spec/devise_zxcvbn/email_tokeniser_spec.rb
@@ -10,6 +10,10 @@ describe DeviseZxcvbn::EmailTokeniser do
     expect(split("björn@email.com")).to eq(%w(björn email com))
   end
 
+  it "should return empty array when email is nil" do
+    expect(split(nil)).to eq([])
+  end
+
   def split(email)
     DeviseZxcvbn::EmailTokeniser.split(email)
   end


### PR DESCRIPTION
When email is nil the application raise `NoMethodError: undefined method 'split' for nil:NilClass`.