### PR TITLE
Rename password check method, add specs to cover skipping password complexity check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ en:
       weak_password: "not strong enough. Consider adding a number, symbols or more letters to make it stronger."
 ```
 
+### Skipping password complexity validation
+
+If you have a suitably sized test suite that creates a significant number of resources which validate password complexity, your test suite execution time will increase.
+
+To turn off password complexity validation for certain conditions, you could implement a concern (or similar) that overloads `check_password_complexity?`:
+
+```ruby
+def check_password_complexity?
+  false if Rails.env.test? # skip password validation for test
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/devise_zxcvbn/model.rb
+++ b/lib/devise_zxcvbn/model.rb
@@ -11,7 +11,7 @@ module Devise
       delegate :zxcvbn_tester, to: "self.class"
 
       included do
-        validate :not_weak_password, if: :password_required?
+        validate :strong_password, if: :check_password_complexity?
       end
 
       def password_score
@@ -24,7 +24,7 @@ module Devise
 
       private
 
-      def not_weak_password
+      def strong_password
         if errors.messages.blank? && password_weak?
           errors.add :password, :weak_password, i18n_variables
         end


### PR DESCRIPTION
In a large test suite, password complexity validation significantly increased the test suite execution time.

The validation can be skipped pending overloading of `password_required?`, however, the method didn't quite capture its intended purposed.

This PR attempts to clarify its purpose, to add specs that cover the purpose and to add documentation around it.

If possible, I'd like to know the intent of the following line:

`if errors.messages.blank? && password_weak?`

What is the intended purpose of `errors.messages.blank?`?