### PR TITLE
Add old default for 'skip_password_complexity?' closes #36

### DIFF
--- a/lib/devise_zxcvbn/model.rb
+++ b/lib/devise_zxcvbn/model.rb
@@ -22,6 +22,12 @@ module Devise
         password_score.score < min_password_score
       end
 
+      protected
+
+      def skip_password_complexity?
+        !password_required?
+      end
+
       private
 
       def strong_password


### PR DESCRIPTION
As it was said, the old behavior of gem is damaged by not setting the default for `skip_password_complexity?`. So, fixing that.