### PR TITLE
Pure-ruby version of devise_zxcvbn (?)

### DIFF
--- a/devise_zxcvbn.gemspec
+++ b/devise_zxcvbn.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug"
 
   spec.add_runtime_dependency "devise"
-  spec.add_runtime_dependency("zxcvbn-js", "~> 4.4.1")
+  spec.add_runtime_dependency "zxcvbn-ruby", "~> 1.0"
 end

--- a/lib/devise_zxcvbn.rb
+++ b/lib/devise_zxcvbn.rb
@@ -12,10 +12,6 @@ module Devise
     raise "The min_password_score must be an integer and between 0..4" unless (0..4).include?(score)
     @@min_password_score = score
   end
-
-  def self.zxcvbn_tester
-    @@zxcvbn_tester ||= ::Zxcvbn::Tester.new
-  end
 end
 
 # Load default I18n

--- a/lib/devise_zxcvbn/model.rb
+++ b/lib/devise_zxcvbn/model.rb
@@ -8,7 +8,6 @@ module Devise
       extend ActiveSupport::Concern
 
       delegate :min_password_score, to: "self.class"
-      delegate :zxcvbn_tester, to: "self.class"
 
       included do
         validate :strong_password, unless: :skip_password_complexity?
@@ -58,7 +57,6 @@ module Devise
 
       class_methods do
         Devise::Models.config(self, :min_password_score)
-        Devise::Models.config(self, :zxcvbn_tester)
 
         def password_score(user, arg_email = nil)
           return raise DeviseZxcvbnError, "the object must respond to password" unless user.respond_to?(:password)
@@ -84,7 +82,7 @@ module Devise
             zxcvbn_weak_words += local_weak_words
           end
 
-          zxcvbn_tester.test(password, zxcvbn_weak_words)
+          Zxcvbn.test(password, zxcvbn_weak_words)
         end
       end
     end


### PR DESCRIPTION
Hi Bit Zesty - thank you for this amazing backend integration for zxcvbn.

I was wondering if there's a strong rationale behind using the ExecJs version of zxcvbn rather than the pure Ruby one? I made the changes below and it dramatically increased the performance of my tests, but I appreciate the ExecJs version may have some advantages (more actively maintained?) that I'm not aware of.