### PR TITLE
Update method invocation for Ruby 3.0

### DIFF
--- a/lib/devise_zxcvbn/model.rb
+++ b/lib/devise_zxcvbn/model.rb
@@ -32,7 +32,7 @@ module Devise
 
       def strong_password
         if errors.messages.blank? && password_weak?
-          errors.add :password, :weak_password, i18n_variables
+          errors.add :password, :weak_password, **i18n_variables
         end
       end
 


### PR DESCRIPTION
Ruby 3.0 [separates positional from keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), which renders a call in the gem not to work anymore. Splatting the hash makes the methods work again.