### PR TITLE
replace zxcvbn-js with alternative gem that won't load js engine.

### DIFF
--- a/devise_zxcvbn.gemspec
+++ b/devise_zxcvbn.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug"
 
   spec.add_runtime_dependency "devise"
-  spec.add_runtime_dependency("zxcvbn", "~> 0.1.6")
+  spec.add_runtime_dependency("zxcvbn", "~> 0.1.7")
 end

--- a/devise_zxcvbn.gemspec
+++ b/devise_zxcvbn.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug"
 
   spec.add_runtime_dependency "devise"
-  spec.add_runtime_dependency("zxcvbn-js", "~> 4.4.1")
+  spec.add_runtime_dependency("zxcvbn", "~> 0.1.6")
 end


### PR DESCRIPTION
By using this gem, which is a 100% ruby rewrite of zxcvbn-js, you will get the same result as zxcvbn-js without loading execjs.
With my own tests I could see a considerable gain in speed.