### PR TITLE
use ActionView::Helpers::DateHelper for crack_time_display

### DIFF
--- a/devise_zxcvbn.gemspec
+++ b/devise_zxcvbn.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "activemodel"
+  spec.add_development_dependency "actionview"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/devise_zxcvbn/model.rb
+++ b/lib/devise_zxcvbn/model.rb
@@ -6,6 +6,7 @@ module Devise
   module Models
     module Zxcvbnable
       extend ActiveSupport::Concern
+      include ActionView::Helpers::DateHelper
 
       delegate :min_password_score, to: "self.class"
       delegate :zxcvbn_tester, to: "self.class"
@@ -53,7 +54,7 @@ module Devise
       end
 
       def time_to_crack
-        password_score.crack_times_display["offline_fast_hashing_1e10_per_second"]
+        distance_of_time_in_words(Time.now, Time.now + password_score.crack_times_seconds["offline_fast_hashing_1e10_per_second"], include_seconds: true)
       end
 
       class_methods do

--- a/spec/devise_zxcvbn/model_spec.rb
+++ b/spec/devise_zxcvbn/model_spec.rb
@@ -1,4 +1,5 @@
 require 'active_model'
+require 'action_view'
 require 'devise'
 require 'devise_zxcvbn'
 require 'devise_zxcvbn/model'
@@ -24,6 +25,7 @@ describe Devise::Models::Zxcvbnable do
 
         expect(password_score.score).to eq(4)
         expect(password_score.crack_times_display['offline_fast_hashing_1e10_per_second']).to eq('12 days')
+        expect(user.send(:time_to_crack)).to eq('12 days')
       end
     end
 
@@ -35,6 +37,7 @@ describe Devise::Models::Zxcvbnable do
 
         expect(password_score.score).to eq(0)
         expect(password_score.crack_times_display['offline_fast_hashing_1e10_per_second']).to eq('less than a second')
+        expect(user.send(:time_to_crack)).to eq('less than 5 seconds')
       end
     end
   end


### PR DESCRIPTION
Since `crack_time_display` gets passed as a I18n variable, it would be nice if it would be already translated with `distance_of_time_in_words`. Else it doesn't make sense to use it with other languages