### PR TITLE
Update required version of zxcvbn to 0.1.9

### DIFF
--- a/devise_zxcvbn.gemspec
+++ b/devise_zxcvbn.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug"
 
   spec.add_runtime_dependency "devise"
-  spec.add_runtime_dependency("zxcvbn", "~> 0.1.7")
+  spec.add_runtime_dependency("zxcvbn", "~> 0.1.9")
 end


### PR DESCRIPTION
Results produced are still compatible with dropbox/zxcvbn.js 4.4.2 but this one solves an issue with performance that could cause considerable impacts. 

This version makes the algorithm to work with performance linear `O(n)` in relation to size of passwords, before this change it could be polynomial `O(n^c)`.

There are more details on `zxcvbn` Changelog and on issue: formigarafa/zxcvbn-rb#6 and the code changes on PR formigarafa/zxcvbn-rb#7.
