### PR TITLE
Add ostruct as an explicit dependency

### DIFF
--- a/devise_zxcvbn.gemspec
+++ b/devise_zxcvbn.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "byebug"
 
+  spec.add_runtime_dependency "ostruct", "~> 0.1"
   spec.add_runtime_dependency "devise"
   spec.add_runtime_dependency("zxcvbn", "~> 0.1.9")
 end


### PR DESCRIPTION
It's being removed from default gems in Ruby 3.5.0, and currently shows a warning when devise_zxcvbn is used:

```
11:05:21 rails.1              | /usr/src/app/vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.7.1/lib/zeitwerk/core_ext/kernel.rb:34: warning: /usr/local/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
11:05:21 rails.1              | You can add ostruct to your Gemfile or gemspec to silence this warning.
11:05:21 rails.1              | Also please contact the author of devise_zxcvbn-6.0.0 to request adding ostruct into its gemspec.
```